### PR TITLE
Ncsdk 30360 ipc sessions test

### DIFF
--- a/subsys/ipc/ipc_service/lib/pbuf.c
+++ b/subsys/ipc/ipc_service/lib/pbuf.c
@@ -298,6 +298,8 @@ int pbuf_read(struct pbuf *pb, char *buf, uint16_t len)
 uint32_t pbuf_handshake_read(struct pbuf *pb)
 {
 	volatile uint32_t *ptr = pb->cfg->handshake_loc;
+
+	__ASSERT_NO_MSG(ptr);
 	sys_cache_data_invd_range((void *)ptr, sizeof(*ptr));
 	__sync_synchronize();
 	return *ptr;
@@ -306,6 +308,8 @@ uint32_t pbuf_handshake_read(struct pbuf *pb)
 void pbuf_handshake_write(struct pbuf *pb, uint32_t value)
 {
 	volatile uint32_t *ptr = pb->cfg->handshake_loc;
+
+	__ASSERT_NO_MSG(ptr);
 	*ptr = value;
 	__sync_synchronize();
 	sys_cache_data_flush_range((void *)ptr, sizeof(*ptr));

--- a/tests/subsys/ipc/ipc_sessions/Kconfig
+++ b/tests/subsys/ipc/ipc_sessions/Kconfig
@@ -14,3 +14,9 @@ config IPC_TEST_MSG_HEAP_SIZE
 	help
 		Internal heap where all the message data would be copied to be processed
 		linearry in tests.
+
+config IPC_TEST_SKIP_CORE_RESET
+	bool "Skip the tests that includes core resetting"
+	help
+		Some of the cores cannot be safely restarted.
+		Skip the tests that require it in such a cases.

--- a/tests/subsys/ipc/ipc_sessions/Kconfig.sysbuild
+++ b/tests/subsys/ipc/ipc_sessions/Kconfig.sysbuild
@@ -10,4 +10,4 @@ config REMOTE_BOARD
 	string "The board used for remote target"
 	default "nrf5340dk/nrf5340/cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP
 	default "nrf5340dk/nrf5340/cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
-	default "nrf54h20dk/nrf54h20/cpuppr" if BOARD_NRF54H20DK_NRF54H20_CPUAPP
+	default "nrf54h20dk/nrf54h20/cpurad" if BOARD_NRF54H20DK_NRF54H20_CPUAPP

--- a/tests/subsys/ipc/ipc_sessions/boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.overlay
+++ b/tests/subsys/ipc/ipc_sessions/boards/nrf54h20dk_nrf54h20_cpuapp_cpuppr.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/* Replace default ipc0 instance */
+/delete-node/ &ipc0;
+
+ipc0: &cpuapp_cpuppr_ipc {
+	status = "okay";
+	unbound = "detect";
+};
+
+&cpuppr_vevif {
+	status = "okay";
+};
+
+&cpuapp_bellboard {
+	status = "okay";
+};
+
+/ {
+	chosen {
+		/delete-property/ zephyr,bt-hci;
+	};
+};

--- a/tests/subsys/ipc/ipc_sessions/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/subsys/ipc/ipc_sessions/remote/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-/* Replace default ipc0 instance */
+&uart135 {
+	/delete-property/ hw-flow-control;
+};
+
 &ipc0 {
 	compatible = "zephyr,ipc-icmsg";
 	/delete-property/ tx-blocks;

--- a/tests/subsys/ipc/ipc_sessions/src/main.c
+++ b/tests/subsys/ipc/ipc_sessions/src/main.c
@@ -180,6 +180,8 @@ ZTEST(ipc_sessions, test_echo)
 
 ZTEST(ipc_sessions, test_reboot)
 {
+	zassume_false(IS_ENABLED(CONFIG_IPC_TEST_SKIP_CORE_RESET));
+
 	int ret;
 	struct test_ipc_event_state ev;
 	static const struct ipc_test_cmd_reboot cmd_rebond = { { IPC_TEST_CMD_REBOOT }, 10 };

--- a/tests/subsys/ipc/ipc_sessions/sysbuild_cpuppr.conf
+++ b/tests/subsys/ipc/ipc_sessions/sysbuild_cpuppr.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpuppr"

--- a/tests/subsys/ipc/ipc_sessions/testcase.yaml
+++ b/tests/subsys/ipc/ipc_sessions/testcase.yaml
@@ -13,6 +13,13 @@ tests:
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf5340dk/nrf5340/cpuapp
+  sample.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpurad:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_configs:
+      - CONFIG_IPC_TEST_SKIP_CORE_RESET=y
   sample.ipc.ipc_sessions.nrf54h20dk_cpuapp_cpuppr:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
WIP

Assertions in pbuff and nrf54h cpuapp - cpurad test implementation.

Note: the cpurad core reset resets also cpuapp.